### PR TITLE
add empty checks to query, q, filter, and f request variables

### DIFF
--- a/src/Builder.php
+++ b/src/Builder.php
@@ -81,22 +81,22 @@ class Builder extends \Laravel\Scout\Builder
 
             $paginator->appends('query',$this->query);
 
-        } elseif (request()->has('query') && !empty(request('query'))) {
+        } elseif (!empty(request('query'))) {
 
             $paginator->appends('query',request('query'));
 
-        } elseif (request()->has('q') && !empty(request('q'))) {
+        } elseif (!empty(request('q'))) {
 
             $paginator->appends('q',request('q'));
 
         }
 
         //we append either request('filter') or request('f') if set
-        if(request()->has('filter') && !empty(request('filter'))) {
+        if(!empty(request('filter'))) {
 
             $paginator->appends('filter',request('filter'));
 
-        } elseif (request()->has('f') && !empty(request('f'))) {
+        } elseif (!empty(request('f'))) {
 
             $paginator->appends('f',request('f'));
 

--- a/src/Builder.php
+++ b/src/Builder.php
@@ -81,21 +81,25 @@ class Builder extends \Laravel\Scout\Builder
 
             $paginator->appends('query',$this->query);
 
-        } elseif (request()->has('query')) {
+        } elseif (request()->has('query') && !empty(request('query'))) {
 
             $paginator->appends('query',request('query'));
 
-        } elseif (request()->has('q')) {
+        } elseif (request()->has('q') && !empty(request('q'))) {
 
             $paginator->appends('q',request('q'));
 
         }
 
         //we append either request('filter') or request('f') if set
-        if(request()->has('filter')) {
+        if(request()->has('filter') && !empty(request('filter'))) {
+
             $paginator->appends('filter',request('filter'));
-        } elseif (request()->has('f')) {
+
+        } elseif (request()->has('f') && !empty(request('f'))) {
+
             $paginator->appends('f',request('f'));
+
         }
 
         return $paginator;


### PR DESCRIPTION
add empty checks to query, q, filter, and f request variables to eliminate the appendage of empty request variables when the builder paginates